### PR TITLE
refactor(lib): update serde and serde_json to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["json", "web", "url", "parser"]
 license = "MIT"
 
 [dependencies]
-serde = "0.8"
-serde_json = "0.8"
+serde = "0.9"
+serde_json = "0.9"
 url = "1"
 regex = "0.1"
 lazy_static = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 
-name = "queryst"
-version = "1.0.1"
-authors = ["Stanislav Panferov <fnight.m@gmail.com>"]
-description = "Rust query string parser with nesting support"
+name = "queryst-prime"
+version = "2.0.0"
+authors = ["Stanislav Panferov <fnight.m@gmail.com>", "Robert Lord <hello@lord.io>"]
+description = "Rust query string parser with nesting support, forked to update Serde"
 repository = "https://github.com/rustless/queryst"
 keywords = ["json", "web", "url", "parser"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## What is Queryst?
 
-[![Build Status](https://travis-ci.org/rustless/queryst.svg?branch=master)](https://travis-ci.org/rustless/queryst)
+**This is a fork of the original, with serde and serde_json updated to 0.9**
+
+[![Build Status](https://travis-ci.org/rustless/queryst.svg?branch=master)](https://travis-ci.org/lord/queryst-prime)
 
 A query string parsing library for Rust inspired by https://github.com/hapijs/qs. A part of REST-like API micro-framework [Rustless].
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,11 +1,10 @@
-use serde_json::{Value};
-use std::collections::BTreeMap;
+use serde_json::{Value, Map};
 
-pub type Object = BTreeMap<String, Value>;
+type Object = Map<String, Value>;
 
 pub fn object_from_list(obj: &Value) -> Value {
     let list = obj.as_array().unwrap();
-    let mut tree: BTreeMap<String,Value> = BTreeMap::new();
+    let mut tree = Object::new();
 
     for (idx, item) in list.iter().enumerate() {
         tree.insert(idx.to_string(), item.clone());

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -113,7 +113,7 @@ fn merge_list_and_merger(to: &mut Value, from: &Value) -> Option<Value> {
         to_vec.insert(to_index, source_obj.clone());
         None
     } else {
-        let mut new_obj = object_from_list(&to_value(to_vec));
+        let mut new_obj = object_from_list(&to_value(to_vec).expect("query string list merging failed"));
         merge_object_and_merger(&mut new_obj, from);
         return Some(new_obj);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,5 @@
 use regex::Regex;
-use std::collections::BTreeMap;
-use serde_json::{Value};
+use serde_json::{Value, Map, Number};
 use url::percent_encoding::percent_decode;
 
 use merge::merge;
@@ -10,6 +9,8 @@ lazy_static! {
     static ref PARENT_REGEX: Regex = Regex::new(r"^([^][]+)").unwrap();
     static ref CHILD_REGEX: Regex = Regex::new(r"(\[[^][]*\])").unwrap();
 }
+
+type Object = Map<String, Value>;
 
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
@@ -85,14 +86,14 @@ fn cleanup_key(key: &str) -> &str {
 }
 
 fn create_idx_merger(idx: u64, obj: Value) -> Value {
-    let mut tree: BTreeMap<String,Value> = BTreeMap::new();
-    tree.insert("__idx".to_string(), Value::U64(idx));
+    let mut tree = Object::new();
+    tree.insert("__idx".to_string(), Value::Number(Number::from(idx)));
     tree.insert("__object".to_string(), obj);
     return Value::Object(tree)
 }
 
 fn create_object_with_key(key: String, obj: Value) -> Value {
-    let mut tree: BTreeMap<String,Value> = BTreeMap::new();
+    let mut tree = Object::new();
     tree.insert(key, obj);
     return Value::Object(tree)
 }
@@ -128,7 +129,7 @@ fn apply_object(keys: &[String], val: Value) -> Value {
 }
 
 pub fn parse(params: &str) -> ParseResult<Value> {
-    let tree: BTreeMap<String,Value> = BTreeMap::new();
+    let tree = Object::new();
     let mut obj = Value::Object(tree);
     let decoded_params = match decode_component(params) {
         Ok(val) => val,


### PR DESCRIPTION
The Serde update breaks its API, introducing a wrapper around the previous type alias for a BTreeMap. It also updates `to_value` to return a Result instead of a Value directly. I've updated the uses of BTreeMap to refer to the new Map struct instead, and added a `.expect` to the use of `to_value` - I don't think there's any reason it should fail, since our data is definitely serializable, but let me know if you'd prefer a different technique there.

This is a breaking change, since it requires users of queryst to update their serde_json.