### PR TITLE
Make regex crate optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: rust
 script:
   - cargo build --verbose
   - cargo test --verbose
+  - cargo test --no-default-features --verbose
   - cargo doc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 
 name = "queryst"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Stanislav Panferov <fnight.m@gmail.com>", "Robert Lord <hello@lord.io>"]
 description = "Rust query string parser with nesting support, forked to update Serde"
 repository = "https://github.com/rustless/queryst"
 keywords = ["json", "web", "url", "parser"]
 license = "MIT"
 
+[features]
+default = ["regex1"]
+regex1 = ["regex", "lazy_static"]
+
 [dependencies]
 serde = "^1"
 serde_json = "^1"
 url = "^1"
-regex = "^0.2"
-lazy_static = "^1"
+regex = { version = "^0.2", optional = true }
+lazy_static = { version = "^1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 extern crate serde;
 extern crate serde_json;
 
+#[cfg(feature = "regex1")]
 extern crate regex;
 extern crate url;
 
+#[cfg(feature = "regex1")]
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
Regex crate adds significant amount of size to compiled binary. Sometimes it's desirable to trade speed for size.