### PR TITLE
refactor(parser): remove lint warning related to 'try' usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Rust query string parser with nesting support, forked to update S
 repository = "https://github.com/rustless/queryst"
 keywords = ["json", "web", "url", "parser"]
 license = "MIT"
+rust = "1.13"
 
 [features]
 default = ["regex1"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -176,7 +176,7 @@ pub fn parse(params: &str) -> ParseResult<Value> {
     };
     let pairs = parse_pairs(&decoded_params);
     for &(key, value) in pairs.iter() {
-        let parse_key_res = try!(parse_key(key));
+        let parse_key_res = parse_key(key)?;
         let key_chain = &parse_key_res[0..];
         let decoded_value = match decode_component(value.unwrap_or("")) {
             Ok(val) => val,


### PR DESCRIPTION
This change eliminates a compile-time lint warning; the indicated `try!` macro is removed, and an `?` operator is introduced instead.

```rust
warning: use of deprecated item 'try': use the `?` operator instead
   --> src/parser.rs:179:29
    |
179 |         let parse_key_res = try!(parse_key(key));
```